### PR TITLE
Potential fix for code scanning alert no. 2: Application backup allowed

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
 
     <application
         android:name=".ApplicationStartup"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"


### PR DESCRIPTION
Potential fix for [https://github.com/adadaptedinc/android-adapted/security/code-scanning/2](https://github.com/adadaptedinc/android-adapted/security/code-scanning/2)

To fix the issue, the `android:allowBackup` attribute in the `<application>` element should be set to `false`. This ensures that automatic backups are disabled for the application, mitigating the risk of sensitive data being exposed through backup files. The change should be made directly in the `AndroidManifest.xml` file by modifying the `<application>` element.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
