### PR TITLE
Adding support for local SDK composite builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@
 .externalNativeBuild
 .cxx
 .kotlin/
-local.properties

--- a/README.md
+++ b/README.md
@@ -34,6 +34,29 @@ any change is compiled straight into the app on the next build — no
 **You don't have to clone it yourself** — if the folder is missing, the first
 Gradle sync auto-clones it from GitHub for you.
 
+#### Keeping the local SDK up to date
+
+The auto-clone is a **one-time bootstrap, not a sync** — it only runs when the
+folder is absent. Once `../android-sdk` exists, Gradle builds against whatever is
+checked out there and **never updates it for you**. Two consequences:
+
+- The `com.github.adadaptedinc:android-sdk:5.0.0` version in `app/build.gradle`
+  is **ignored** in local mode — the composite build substitutes it for your
+  on-disk source regardless of the version string. When the SDK is tagged, say,
+  `5.1.0`, you will *not* pick it up until you update the checkout yourself:
+
+  ```
+  cd ../android-sdk && git pull
+  ```
+
+- To make the version string meaningful again (i.e. consume the published
+  artifact), set `adadapted.sdk.local=false` in `local.properties` and bump the
+  version in `app/build.gradle`.
+
+Each sync prints the checked-out SDK revision, e.g.
+`Building against local SDK source at … (5.0.0)` or `… (5.0.0-4-g1a2b3c-dirty)`,
+so a stale checkout is visible at a glance.
+
 Configuration (all optional, per-developer, via the gitignored `local.properties`):
 
 | Property | Default | Purpose |

--- a/README.md
+++ b/README.md
@@ -11,3 +11,41 @@ Official documentation for integrating the SDK libraries can be found at [https:
 ### Installing
 
 Simply clone the repository and load it up into Android Studio with the required plugins and updates. The app is supplied already with a test API key that is used for a suite of test ads and keywords to interact with.
+
+### Developing against the SDK source (local composite build)
+
+By default this app pulls the **published** AdAdapted SDK artifact. If you want to
+read and edit the SDK source directly from this project, check out the
+[`android-sdk`](https://github.com/adadaptedinc/android-sdk) repo as a **sibling
+folder** of this one:
+
+```
+GitHub/
+├── android-adapted/   <- this project
+└── android-sdk/       <- SDK source
+```
+
+When `../android-sdk` is present, `settings.gradle` automatically wires it in as a
+Gradle [composite build](https://docs.gradle.org/current/userguide/composite_builds.html):
+the SDK modules show up in the Android Studio project view (fully editable), and
+any change is compiled straight into the app on the next build — no
+`maven publish` / JitPack round-trip.
+
+**You don't have to clone it yourself** — if the folder is missing, the first
+Gradle sync auto-clones it from GitHub for you.
+
+Configuration (all optional, per-developer, via the gitignored `local.properties`):
+
+| Property | Default | Purpose |
+|----------|---------|---------|
+| `adadapted.sdk.local` | `true` | Set to `false` to force the published artifact and ignore any local checkout. |
+| `adadapted.sdk.path`  | `../android-sdk` | Point at a different location for the SDK checkout (absolute or relative to this project). |
+
+> Composite builds require a single Android Gradle Plugin version across both
+> projects. This app is aligned to the SDK's AGP version; if you bump one, bump
+> the other.
+
+> **Gradle JDK:** the current AGP requires the Gradle daemon to run on **JDK 17
+> or newer**. If Android Studio reports *"Gradle JVM version incompatible"*, set
+> **Settings → Build, Execution, Deployment → Build Tools → Gradle → Gradle JDK**
+> to the embedded JBR (or any JDK 17+) and re-sync.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,8 +60,11 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2'
 
     // AdAdapted SDK
-    //implementation 'com.adadapted:android-sdk:5.0.0' //Local Sdk
-    implementation 'com.github.adadaptedinc:android-sdk:5.0.0' //Live Sdk
+    // Resolves to the published artifact by default. When the android-sdk repo
+    // is present as a sibling checkout, settings.gradle transparently swaps this
+    // for the local :advertising_sdk source via a composite build -- no change
+    // needed here. See the "Local AdAdapted SDK" section in settings.gradle.
+    implementation 'com.github.adadaptedinc:android-sdk:5.0.0'
 
     // Firebase
     implementation 'com.google.firebase:firebase-messaging-ktx:23.2.1'

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.11.1'
+        classpath 'com.android.tools.build:gradle:8.13.2'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.0'
         classpath 'org.jetbrains.kotlin:compose-compiler-gradle-plugin:2.3.0'
         classpath 'com.google.gms:google-services:4.4.0'

--- a/settings.gradle
+++ b/settings.gradle
@@ -41,20 +41,43 @@ def useLocalSdk = !'false'.equalsIgnoreCase(localProp('adadapted.sdk.local') ?: 
 def sdkPathProp = localProp('adadapted.sdk.path') ?: '../android-sdk'
 def sdkDir = new File(sdkPathProp).absolute ? new File(sdkPathProp) : new File(rootDir, sdkPathProp)
 
+// Best-effort description of the checked-out SDK revision (nearest tag, else short
+// hash, with a `-dirty` suffix for uncommitted changes). Purely informational so a
+// stale local checkout is visible in the sync log -- never fails the build.
+def sdkRef = { File dir ->
+    try {
+        def p = ['git', '-C', dir.absolutePath, 'describe', '--tags', '--always', '--dirty'].execute()
+        p.waitFor()
+        return p.exitValue() == 0 ? p.text.trim() : null
+    } catch (Exception ignored) {
+        return null
+    }
+}
+
 if (useLocalSdk) {
     if (!sdkDir.exists()) {
         println "[adadapted-sdk] Local SDK not found at ${sdkDir.canonicalPath} -- cloning from ${sdkRepoUrl} ..."
-        sdkDir.parentFile.mkdirs()
-        def clone = ['git', 'clone', sdkRepoUrl, sdkDir.absolutePath].execute()
-        clone.consumeProcessOutput(System.out, System.err)
-        clone.waitFor()
-        if (clone.exitValue() != 0) {
-            println "[adadapted-sdk] Clone failed -- falling back to the published artifact."
+        try {
+            sdkDir.parentFile.mkdirs()
+            def clone = ['git', 'clone', sdkRepoUrl, sdkDir.absolutePath].execute()
+            clone.consumeProcessOutput(System.out, System.err)
+            clone.waitFor()
+            if (clone.exitValue() != 0) {
+                println "[adadapted-sdk] Clone failed -- falling back to the published artifact."
+                sdkDir.deleteDir()
+            }
+        } catch (Exception e) {
+            // e.g. git not installed / not on PATH -- don't break the build,
+            // just fall back to the published artifact.
+            println "[adadapted-sdk] Could not clone SDK (${e.message}) -- falling back to the published artifact."
+            sdkDir.deleteDir()
         }
     }
 
     if (sdkDir.exists()) {
-        println "[adadapted-sdk] Building against local SDK source at ${sdkDir.canonicalPath}"
+        def ref = sdkRef(sdkDir)
+        println "[adadapted-sdk] Building against local SDK source at ${sdkDir.canonicalPath}${ref ? " (${ref})" : ''}"
+        println "[adadapted-sdk] This checkout does NOT auto-update -- run `git pull` in it to get newer SDK versions."
         includeBuild(sdkDir) {
             dependencySubstitution {
                 // Substitute both the live (jitpack) and local maven coordinates

--- a/settings.gradle
+++ b/settings.gradle
@@ -39,7 +39,7 @@ def localProp = { String key ->
 def sdkRepoUrl = 'https://github.com/adadaptedinc/android-sdk.git'
 def useLocalSdk = !'false'.equalsIgnoreCase(localProp('adadapted.sdk.local') ?: 'true')
 def sdkPathProp = localProp('adadapted.sdk.path') ?: '../android-sdk'
-def sdkDir = new File(sdkPathProp).absolute ? new File(sdkPathProp) : new File(rootDir, sdkPathProp)
+def sdkDir = new File(sdkPathProp).isAbsolute() ? new File(sdkPathProp) : new File(rootDir, sdkPathProp)
 
 // Best-effort description of the checked-out SDK revision (nearest tag, else short
 // hash, with a `-dirty` suffix for uncommitted changes). Purely informational so a

--- a/settings.gradle
+++ b/settings.gradle
@@ -80,10 +80,9 @@ if (useLocalSdk) {
         println "[adadapted-sdk] This checkout does NOT auto-update -- run `git pull` in it to get newer SDK versions."
         includeBuild(sdkDir) {
             dependencySubstitution {
-                // Substitute both the live (jitpack) and local maven coordinates
-                // so app/build.gradle needs no changes.
+                // Substitute the JitPack coordinate declared in app/build.gradle
+                // for the local source, so no change is needed there.
                 substitute module('com.github.adadaptedinc:android-sdk') using project(':advertising_sdk')
-                substitute module('com.adadapted:android-sdk') using project(':advertising_sdk')
             }
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -80,7 +80,14 @@ if (useLocalSdk) {
         }
     }
 
-    if (sdkDir.exists()) {
+    // A bare `exists()` check isn't enough: a path that exists but isn't a valid
+    // Gradle build (empty folder, a stray file, or a partial/failed clone) would
+    // make includeBuild hard-fail the sync. Require a directory with a settings
+    // file before including it; otherwise log and fall back to the published artifact.
+    def hasSettings = { File dir ->
+        new File(dir, 'settings.gradle').exists() || new File(dir, 'settings.gradle.kts').exists()
+    }
+    if (sdkDir.isDirectory() && hasSettings(sdkDir)) {
         def ref = sdkRef(sdkDir)
         println "[adadapted-sdk] Building against local SDK source at ${sdkDir.absolutePath}${ref ? " (${ref})" : ''}"
         println "[adadapted-sdk] This checkout does NOT auto-update -- run `git pull` in it to get newer SDK versions."
@@ -91,6 +98,8 @@ if (useLocalSdk) {
                 substitute module('com.github.adadaptedinc:android-sdk') using project(':advertising_sdk')
             }
         }
+    } else if (sdkDir.exists()) {
+        println "[adadapted-sdk] ${sdkDir.absolutePath} exists but is not a valid Gradle build (no settings.gradle[.kts]) -- falling back to the published artifact."
     }
 } else {
     println "[adadapted-sdk] adadapted.sdk.local=false -- using the published SDK artifact."

--- a/settings.gradle
+++ b/settings.gradle
@@ -56,27 +56,33 @@ def sdkRef = { File dir ->
 
 if (useLocalSdk) {
     if (!sdkDir.exists()) {
-        println "[adadapted-sdk] Local SDK not found at ${sdkDir.canonicalPath} -- cloning from ${sdkRepoUrl} ..."
-        try {
-            sdkDir.parentFile.mkdirs()
-            def clone = ['git', 'clone', sdkRepoUrl, sdkDir.absolutePath].execute()
-            clone.consumeProcessOutput(System.out, System.err)
-            clone.waitFor()
-            if (clone.exitValue() != 0) {
-                println "[adadapted-sdk] Clone failed -- falling back to the published artifact."
+        if (gradle.startParameter.offline) {
+            // Gradle is in offline mode -- don't perform network work during
+            // sync; fall back to the published artifact.
+            println "[adadapted-sdk] Local SDK not found at ${sdkDir.absolutePath} and Gradle is offline -- falling back to the published artifact."
+        } else {
+            println "[adadapted-sdk] Local SDK not found at ${sdkDir.absolutePath} -- cloning from ${sdkRepoUrl} ..."
+            try {
+                sdkDir.parentFile.mkdirs()
+                def clone = ['git', 'clone', sdkRepoUrl, sdkDir.absolutePath].execute()
+                clone.consumeProcessOutput(System.out, System.err)
+                clone.waitFor()
+                if (clone.exitValue() != 0) {
+                    println "[adadapted-sdk] Clone failed -- falling back to the published artifact."
+                    sdkDir.deleteDir()
+                }
+            } catch (Exception e) {
+                // e.g. git not installed / not on PATH -- don't break the build,
+                // just fall back to the published artifact.
+                println "[adadapted-sdk] Could not clone SDK (${e.message}) -- falling back to the published artifact."
                 sdkDir.deleteDir()
             }
-        } catch (Exception e) {
-            // e.g. git not installed / not on PATH -- don't break the build,
-            // just fall back to the published artifact.
-            println "[adadapted-sdk] Could not clone SDK (${e.message}) -- falling back to the published artifact."
-            sdkDir.deleteDir()
         }
     }
 
     if (sdkDir.exists()) {
         def ref = sdkRef(sdkDir)
-        println "[adadapted-sdk] Building against local SDK source at ${sdkDir.canonicalPath}${ref ? " (${ref})" : ''}"
+        println "[adadapted-sdk] Building against local SDK source at ${sdkDir.absolutePath}${ref ? " (${ref})" : ''}"
         println "[adadapted-sdk] This checkout does NOT auto-update -- run `git pull` in it to get newer SDK versions."
         includeBuild(sdkDir) {
             dependencySubstitution {

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,4 +9,63 @@ dependencyResolutionManagement {
     }
 }
 rootProject.name = "AndroidAdapted"
+
+// ---------------------------------------------------------------------------
+// Local AdAdapted SDK (composite build)
+//
+// When the android-sdk repo is checked out as a sibling of this project, we
+// wire it in as a Gradle composite build so you can see and edit all SDK
+// sources directly from this project, with changes picked up instantly on the
+// next build -- no `maven publish` / jitpack round-trip required.
+//
+// Behaviour:
+//   * Path defaults to ../android-sdk, and is overridable per-developer via
+//     `adadapted.sdk.path` in local.properties (gitignored, not shared).
+//   * If the path is missing it is auto-cloned from GitHub.
+//   * If cloning is unavailable/opted out, we silently fall back to the
+//     published artifact declared in app/build.gradle.
+//
+// To opt OUT of local source on a given machine, set in local.properties:
+//   adadapted.sdk.local=false
+// ---------------------------------------------------------------------------
+def localProp = { String key ->
+    def f = new File(rootDir, 'local.properties')
+    if (!f.exists()) return null
+    def props = new Properties()
+    f.withInputStream { props.load(it) }
+    return props.getProperty(key)?.trim()
+}
+
+def sdkRepoUrl = 'https://github.com/adadaptedinc/android-sdk.git'
+def useLocalSdk = !'false'.equalsIgnoreCase(localProp('adadapted.sdk.local') ?: 'true')
+def sdkPathProp = localProp('adadapted.sdk.path') ?: '../android-sdk'
+def sdkDir = new File(sdkPathProp).absolute ? new File(sdkPathProp) : new File(rootDir, sdkPathProp)
+
+if (useLocalSdk) {
+    if (!sdkDir.exists()) {
+        println "[adadapted-sdk] Local SDK not found at ${sdkDir.canonicalPath} -- cloning from ${sdkRepoUrl} ..."
+        sdkDir.parentFile.mkdirs()
+        def clone = ['git', 'clone', sdkRepoUrl, sdkDir.absolutePath].execute()
+        clone.consumeProcessOutput(System.out, System.err)
+        clone.waitFor()
+        if (clone.exitValue() != 0) {
+            println "[adadapted-sdk] Clone failed -- falling back to the published artifact."
+        }
+    }
+
+    if (sdkDir.exists()) {
+        println "[adadapted-sdk] Building against local SDK source at ${sdkDir.canonicalPath}"
+        includeBuild(sdkDir) {
+            dependencySubstitution {
+                // Substitute both the live (jitpack) and local maven coordinates
+                // so app/build.gradle needs no changes.
+                substitute module('com.github.adadaptedinc:android-sdk') using project(':advertising_sdk')
+                substitute module('com.adadapted:android-sdk') using project(':advertising_sdk')
+            }
+        }
+    }
+} else {
+    println "[adadapted-sdk] adadapted.sdk.local=false -- using the published SDK artifact."
+}
+
 include ':app'


### PR DESCRIPTION
This PR lets us read and edit the AdAdapted SDK source directly from this app instead of round-tripping through JitPack/maven publish.

Main Changes:

  - settings.gradle -> When android-sdk is checked out as a sibling folder, it's automatically wired in as a Gradle composite build, substituting the com.github.adadaptedinc:android-sdk dependency for the local :advertising_sdk source. If the folder is missing, it's auto-cloned from GitHub on first sync; if git is unavailable or opted out, it silently falls back to the published artifact. Each sync logs the checked-out SDK revision so a stale checkout is visible at a glance.
  - build.gradle -> Bumped Android Gradle Plugin 8.11.1 → 8.13.2 to align with the SDK.
  - README.md -> Documented the local-SDK workflow, keeping the checkout up to date, the adadapted.sdk.local / adadapted.sdk.path config options, and the AGP/JDK 17+ requirements.